### PR TITLE
Make mail optional

### DIFF
--- a/lib/s3_mysql_backup.rb
+++ b/lib/s3_mysql_backup.rb
@@ -61,6 +61,7 @@ class S3MysqlBackup
   end
 
   def mail_notification(filename)
+    return unless config['mail_to']
     stats = File.stat(filename)
     subject = "sql backup: #{@db_name}: #{human_size(stats.size)}"
 


### PR DESCRIPTION
Omit mailing by leaving the mail_to key unset in the configuration file.
