### PR TITLE
Allow mailers other than gmail and accept ruby hash for configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Configure with a YAML file:
 
 # backup_dir            where to store the local backups
 backup_dir: ~/s3_mysql_backups
+# remote_dir            where to store the remote backups
+remote_dir: /path/to/remote/backups
 
 # s3_access_key_id      your Amazon S3 access_key_id
 # s3_secret_access_key  your Amazon S3 secret_access_key

--- a/lib/s3_mysql_backup.rb
+++ b/lib/s3_mysql_backup.rb
@@ -42,7 +42,7 @@ class S3MysqlBackup
     filename  = Time.now.strftime("#{@backup_dir}/#{@db_name}.%Y%m%d.%H%M%S.sql.gz")
     mysqldump = `which mysqldump`.to_s.strip
     `#{mysqldump} --host='#{config['dump_host']}' --user='#{config['dump_user']}' --password='#{config['dump_pass']}' '#{@db_name}' | gzip > #{filename}`
-    @s3utils.store(filename)
+    @s3utils.store(filename, config['remote_dir'])
     filename
   end
 

--- a/lib/s3utils.rb
+++ b/lib/s3utils.rb
@@ -11,8 +11,9 @@ class S3Utils
     self
   end
 
-  def store(file_path)
-    @s3_bucket.objects.create(File.basename(file_path), open(file_path))
+  def store(file_path, remote_path=nil)
+    upload_location = (!remote_path.nil? && !remote_path.empty?) ? "#{remote_path}/#{File.basename(file_path)}" : File.basename(file_path)
+    @s3_bucket.objects.create(upload_location, open(file_path))
   end
 
   def delete(file_path)


### PR DESCRIPTION
I don't know how necessary these changes are but I figured I would offer them up.

I needed a way to specify the mail server and domain (since we aren't using gmail).  So I modified the mail config to accept more options.

I also modified the path_to_config to also accept a Hash so that you can do things like:

``` ruby
databases = ActiveRecord::Base.connection.execute("show databases;").to_a.flatten - ["information_schema", "mysql", "performance_schema", "test"]
default_options = YAML::load_file(Rails.root,join('config', 'backup.yml'))
databases.each do |db|
  S3MysqlBackup.new(db, default_options.merge(backup_dir: "path/to/backup/#{db}")).run
end
```
