### PR TITLE
Added support for mail from address

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ mail_to: recipient@example.com
 # Mail credentials
 mail_user: me@example.com
 mail_pass: example_password
+mail_from: noreply@example.com  # OPTIONAL, defaults to mail_user
 mail_domain: smtp.example.com   # OPTIONAL, defaults to: smtp.gmail.com
 mail_port: 587                  # OPTIONAL, defaults to: 587
 mail_authentication: login      # OPTIONAL, defaults to: :login

--- a/lib/s3_mysql_backup.rb
+++ b/lib/s3_mysql_backup.rb
@@ -77,9 +77,10 @@ class S3MysqlBackup
     return unless config['mail_to']
     stats = File.stat(filename)
     subject = "sql backup: #{@db_name}: #{human_size(stats.size)}"
+    mail_from = config['mail_from'] ? config['mail_from'] : config['mail_user']
 
     content = []
-    content << "From: #{config['mail_user']}"
+    content << "From: #{mail_from}"
     content << "To: #{config['mail_to']}"
     content << "Subject: #{subject}"
     content << "Date: #{Time.now.rfc2822}"
@@ -89,7 +90,7 @@ class S3MysqlBackup
     smtp = Net::SMTP.new(config["mail_domain"], config["mail_port"])
     smtp.enable_starttls unless config["mail_start_tls"] == false
     smtp.start(config["mail_domain"], config['mail_user'], config['mail_pass'], config['mail_authentication']) do
-      smtp.send_message(content, config['mail_user'], config['mail_to'])
+      smtp.send_message(content, mail_from, config['mail_to'])
     end
   end
 


### PR DESCRIPTION
I'm using Amazon SES to send emails and the SMTP username is not an email address. I needed to be able to specify a separate parameter to use as the from address. I've introduced a new configruation parameter, mail_from, for this purpose. The default behavior is unchanged, it will use the value of mail_user as the from address, just like before.
