### PR TITLE
Fixes an issue with processing backups for database names with periods in their name.

### DIFF
--- a/lib/s3_mysql_backup.rb
+++ b/lib/s3_mysql_backup.rb
@@ -111,7 +111,7 @@ class S3MysqlBackup
     path = File.expand_path(config['backup_dir'])
 
     Dir["#{path}/*.sql.gz"].each do |name|
-      date     = name.split('.')[1]
+      date     = name.split('.')[-4]
       filedate = Date.strptime(date, '%Y%m%d')
 
       if filedate < weekly && filedate >= monthly


### PR DESCRIPTION
I have databases with periods (`.`) in the name, and while that's fully supported by MySQL, it chokes up s3-mysql-backup. I just changed the code to look for the date starting from the end (which is always known because of how the `filename` variable is created). 

That solved the problem for me and won't cause problems for anyone else.

Just submitting a PR in the hope that it might be of help. 😄